### PR TITLE
bugfixes for static frequency interval

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1057,6 +1057,7 @@ def main_v03(argv):
         break_network_at_waterbodies,
         param_df.index,
         lastobs_df.index,
+        t0,
         showtiming,
         verbose,
         debuglevel,
@@ -1064,7 +1065,7 @@ def main_v03(argv):
 
     for run_set_iterator, run in enumerate(run_sets):
 
-        run["t0"] = t0
+        t0 = run.get("t0")
         dt = run.get("dt")
         nts = run.get("nts")
 
@@ -1114,6 +1115,7 @@ def main_v03(argv):
                 break_network_at_waterbodies,
                 param_df.index,
                 lastobs_df.index,
+                t0 + timedelta(seconds = dt * nts),
                 showtiming,
                 verbose,
                 debuglevel,
@@ -1141,7 +1143,6 @@ def main_v03(argv):
             verbose,
             debuglevel,
         )
-        t0 = t0 + timedelta(seconds = dt * nts)
 
     # nwm_final_output_generator()
 

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -574,7 +574,8 @@ def _run_everything_v02(
             print("creating usgs time_slice data array ...")
 
             usgs_df, lastobs_df, da_parameter_dict = nnu.build_data_assimilation(
-                data_assimilation_parameters
+                data_assimilation_parameters,
+                run_parameters,
             )
 
         if verbose:

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1121,8 +1121,10 @@ def main_v03(argv):
 
             q0 = new_nwm_q0(run_results)
 
-            lastobs_df = new_lastobs(run_results, dt * nts)
+            if data_assimilation_parameters:
+                lastobs_df = new_lastobs(run_results, dt * nts)
 
+            # TODO: Confirm this works with Waterbodies turned off
             waterbodies_df = get_waterbody_water_elevation(waterbodies_df, q0)
 
         nwm_output_generator(

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -555,9 +555,9 @@ def _run_everything_v02(
     data_assimilation_folder = data_assimilation_parameters.get(
         "data_assimilation_timeslices_folder", None
     )
-    last_obs_file = data_assimilation_parameters.get("wrf_hydro_last_obs_file", None)
+    lastobs_file = data_assimilation_parameters.get("wrf_hydro_lastobs_file", None)
 
-    if data_assimilation_csv or data_assimilation_folder or last_obs_file:
+    if data_assimilation_csv or data_assimilation_folder or lastobs_file:
         if showtiming:
             start_time = time.time()
         if verbose:

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1031,9 +1031,10 @@ def main_v03(argv):
     run_sets = forcing_parameters.get("qlat_forcing_sets", False)
 
     if "data_assimilation_parameters" in compute_parameters:
-        da_sets = data_assimilation_parameters.get("data_assimilation_sets", [])
-    else:
-        da_sets = []
+        if "data_assimilation_sets" in data_assimilation_parameters:
+            da_sets = data_assimilation_parameters.get("data_assimilation_sets", [])
+        else:
+            da_sets = [{} for _ in run_sets]
 
     if "wrf_hydro_parity_check" in output_parameters:
         parity_sets = parity_parameters.get("parity_check_compare_file_sets", [])

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -77,12 +77,12 @@ def nwm_network_preprocess(
         wbtype = "hybrid_and_rfc"
         wb_params_hybrid_and_rfc = waterbody_parameters.get(
             wbtype, defaultdict(list)
-        )  # TODO: Convert these to `get` statments
+        )
 
         wbtype = "level_pool"
         wb_params_level_pool = waterbody_parameters.get(
             wbtype, defaultdict(list)
-        )  # TODO: Convert these to `get` statments
+        )
 
         # Determine if any data assimilation reservoirs are activated, and if so, read
         # the reservoir parameter file

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -293,6 +293,8 @@ def nwm_forcing_preprocess(
         lastobs_type = data_assimilation_parameters.get("wrf_lastobs_type", "error-based")
         lastobs_crosswalk_file = data_assimilation_parameters.get("wrf_hydro_da_channel_ID_crosswalk_file", None)
         da_decay_coefficient = data_assimilation_parameters.get("da_decay_coefficient", 120)
+        qc_threshold = data_assimilation_parameters.get("qc_threshold", 1.0)
+        da_max_fill = data_assimilation_parameters.get("da_max_fill", 59)
 
         da_run["data_assimilation_timeslices_folder"] = da_run.get("data_assimilation_timeslices_folder", data_assimilation_folder)
         da_run["data_assimilation_csv"] = da_run.get("data_assimilation_csv", data_assimilation_csv)
@@ -301,6 +303,8 @@ def nwm_forcing_preprocess(
         da_run["wrf_lastobs_type"] = da_run.get("wrf_lastobs_type", lastobs_type)
         da_run["wrf_hydro_da_channel_ID_crosswalk_file"] = da_run.get("wrf_hydro_da_channel_ID_crosswalk_file", lastobs_crosswalk_file)
         da_run["da_decay_coefficient"] = da_run.get("da_decay_coefficient", da_decay_coefficient)
+        da_run["qc_threshold"] = da_run.get("QC_threshold", qc_threshold)
+        da_run["da_max_fill"] = da_run.get("da_max_fill", da_max_fill)
 
     # STEP 5: Read (or set) QLateral Inputs
     if showtiming:
@@ -333,7 +337,7 @@ def nwm_forcing_preprocess(
         if verbose:
             print("creating usgs time_slice data array ...")
 
-        usgs_df = nnu.build_data_assimilation_usgs_df(da_run, lastobs_index, run["t0"])
+        usgs_df = nnu.build_data_assimilation_usgs_df(da_run, run, lastobs_index)
 
         if verbose:
             print("usgs array complete")

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -167,14 +167,6 @@ def nwm_initial_warmstate_preprocess(
         if verbose:
             print("setting waterbody initial states ...")
 
-        if restart_parameters.get("wrf_hydro_channel_restart_file",None):
-            channel_initial_states_file = restart_parameters["wrf_hydro_channel_restart_file"]
-            t0_str = nhd_io.get_param_str(channel_initial_states_file, "Restart_Time")
-        else:
-            t0_str = "2015-08-16_00:00:00"
-
-        t0 = datetime.strptime(t0_str, "%Y-%m-%d_%H:%M:%S")
-
         if restart_parameters.get("wrf_hydro_waterbody_restart_file", None):
             waterbodies_initial_states_df = nhd_io.get_reservoir_restart_from_wrf_hydro(
                 restart_parameters["wrf_hydro_waterbody_restart_file"],
@@ -216,13 +208,21 @@ def nwm_initial_warmstate_preprocess(
             print("... in %s seconds." % (time.time() - start_time))
             start_time = time.time()
 
-    # STEP 4: Handle Channel Initial States
+    # STEP 4: Handle Channel Initial States and Set T0
     if showtiming:
         start_time = time.time()
     if verbose:
         print("setting channel initial states ...")
 
     q0 = nnu.build_channel_initial_state(restart_parameters, segment_index)
+
+    if restart_parameters.get("wrf_hydro_channel_restart_file",None):
+        channel_initial_states_file = restart_parameters["wrf_hydro_channel_restart_file"]
+        t0_str = nhd_io.get_param_str(channel_initial_states_file, "Restart_Time")
+    else:
+        t0_str = "2015-08-16_00:00:00"
+
+    t0 = datetime.strptime(t0_str, "%Y-%m-%d_%H:%M:%S")
 
     if verbose:
         print("channel initial states complete")

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -55,6 +55,8 @@ def nwm_network_preprocess(
     # waterbodies_segments = supernetwork_values[13]
     # connections_tailwaters = supernetwork_values[4]
 
+    waterbody_type_specified = False
+
     if break_network_at_waterbodies:
         # Read waterbody parameters
         waterbodies_df = nhd_io.read_waterbody_df(
@@ -81,8 +83,6 @@ def nwm_network_preprocess(
         wb_params_level_pool = waterbody_parameters.get(
             wbtype, defaultdict(list)
         )  # TODO: Convert these to `get` statments
-
-        waterbody_type_specified = False
 
         # Determine if any data assimilation reservoirs are activated, and if so, read
         # the reservoir parameter file
@@ -206,6 +206,10 @@ def nwm_initial_warmstate_preprocess(
                 len(waterbodies_initial_states_df)
             )
 
+        waterbodies_df = pd.merge(
+            waterbodies_df, waterbodies_initial_states_df, on="lake_id"
+        )
+
         if verbose:
             print("waterbody initial states complete")
         if showtiming:
@@ -225,11 +229,6 @@ def nwm_initial_warmstate_preprocess(
     if showtiming:
         print("... in %s seconds." % (time.time() - start_time))
         start_time = time.time()
-
-    # TODO: Does this need to live outside the if-block for waterbodies above? If not, let's move it up there to keep things together.
-    waterbodies_df = pd.merge(
-        waterbodies_df, waterbodies_initial_states_df, on="lake_id"
-    )
 
     last_obs_file = restart_parameters.get("wrf_hydro_last_obs_file", None)
     # TODO: Split apart the da input functions to get last_obs here.

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -257,11 +257,18 @@ def nwm_forcing_preprocess(
     break_network_at_waterbodies,
     segment_index,
     lastobs_index,
+    warmstate_t0 = None,
     showtiming=False,
     verbose=False,
     debuglevel=0,
 ):
 
+    # TODO: Harmonize the t0 parameter -- this
+    # configuration permits the Warm-State derived
+    # t0 to carry as the default if no other value is
+    # provided -- we need to confirm this is
+    # desireable behavior.
+    t0 = forcing_parameters.get("t0", warmstate_t0)
     nts = forcing_parameters.get("nts", None)
     dt = forcing_parameters.get("dt", None)
     qts_subdivisions = forcing_parameters.get("qts_subdivisions", None)
@@ -270,6 +277,7 @@ def nwm_forcing_preprocess(
     qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", None)
 
     # TODO: find a better way to deal with these defaults and overrides.
+    run["t0"] = run.get("t0", t0)
     run["nts"] = run.get("nts", nts)
     run["dt"] = run.get("dt", dt)
     run["qts_subdivisions"] = run.get("qts_subdivisions", qts_subdivisions)
@@ -325,7 +333,7 @@ def nwm_forcing_preprocess(
         if verbose:
             print("creating usgs time_slice data array ...")
 
-        usgs_df = nnu.build_data_assimilation_usgs_df(da_run, lastobs_index)
+        usgs_df = nnu.build_data_assimilation_usgs_df(da_run, lastobs_index, run["t0"])
 
         if verbose:
             print("usgs array complete")

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -653,7 +653,9 @@ def get_usgs_from_time_slices_folder(
     routelink_subset_file,
     usgs_files,
     max_fill_1min = 14,
+    dt = 300,
     t0 = None,
+    qc_threshold = 1.0,
 ):
     """
     routelink_subset_file - provides the gage-->segment crosswalk
@@ -663,6 +665,7 @@ def get_usgs_from_time_slices_folder(
           the interpolated values are truncated so that the first value returned
           corresponds to the first center date of the first provided file.
     """
+    frequency = str(dt/60))+"min"
     with read_netcdfs(usgs_files, "time", preprocess_time_station_index,) as ds2:
 
         # dataframe containing discharge observations
@@ -718,7 +721,7 @@ def get_usgs_from_time_slices_folder(
     date_time_center_end = datetime.strptime(last_center_time, "%Y-%m-%d_%H:%M:%S")
 
     dates = []
-    for j in pd.date_range(date_time_center_start, date_time_center_end, freq="5min"):
+    for j in pd.date_range(date_time_center_start, date_time_center_end, freq=frequency):
         dates.append(j)
 
     """
@@ -760,9 +763,7 @@ def get_usgs_from_time_slices_folder(
     usgs_qual_df = usgs_qual_df.mask(usgs_qual_df > 1, np.nan)
 
     # screen-out poor quality flow observations
-    # TODO: Bring qc_thresh parameter in from yaml as user input
-    qc_trehsh = 1
-    usgs_df = usgs_df.mask(usgs_qual_df < qc_trehsh, np.nan)
+    usgs_df = usgs_df.mask(usgs_qual_df < qc_threshold, np.nan)
 
     # screen-out erroneous flow observations
     usgs_df = usgs_df.mask(usgs_df <= 0, np.nan)
@@ -782,7 +783,7 @@ def get_usgs_from_time_slices_folder(
     # TODO: Add reporting interval information to the gage preprocessing (timeslice generation)
     usgs_df_T = (usgs_df_T.resample('min').
                  interpolate(limit = max_fill_1min, limit_direction = 'both').
-                 resample('5min').
+                 resample(frequency).
                  asfreq().
                  loc[date_time_center_start:,:])
 

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -645,19 +645,14 @@ def get_usgs_from_time_slices_csv(routelink_subset_file, usgs_csv):
 
 def get_usgs_from_time_slices_folder(
     routelink_subset_file,
-    usgs_timeslices_folder,
-    data_assimilation_filter,
+    usgs_files,
     max_fill_1min = 14
 ):
-    # TODO: Use an explicit list for the files. By this point, the globbing should be complete.
     """
     routelink_subset_file - provides the gage-->segment crosswalk
-    usgs_timeslices_folder - folder with timeslices
-    data_assimilation_filter - glob pattern for selecting files
+    usgs_files - list of "time-slice" files containing observed values
     max_fill_1min - sets the maximum interpolation length
     """
-    usgs_files = sorted(usgs_timeslices_folder.glob(data_assimilation_filter))
-
     with read_netcdfs(usgs_files, "time", preprocess_time_station_index,) as ds2:
 
         # dataframe containing discharge observations

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -434,6 +434,9 @@ def get_nc_attributes(nc_list, attribute, file_selection=[0, -1]):
 
 
 def get_attribute(nc_file, attribute):
+    # TODO: consider naming as get_nc_attribute
+    # -- this is really specific to a netcdf file.
+
     with xr.open_dataset(nc_file) as xd:
         return xd.attrs[attribute]
 
@@ -789,14 +792,9 @@ def get_usgs_from_time_slices_folder(
     return usgs_df_new
 
 
-def get_param_str(
-    target_file,
-    param,
-):
-    with xr.open_dataset(target_file) as ds:
-        param_str = ds.attrs[param]
-
-    return param_str
+def get_param_str(target_file, param):
+    # TODO: remove this duplicate function
+    return get_attribute(target_file, param)
 
 
 # TODO: Move channel restart above usgs to keep order with execution script

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -649,12 +649,16 @@ def get_usgs_from_time_slices_csv(routelink_subset_file, usgs_csv):
 def get_usgs_from_time_slices_folder(
     routelink_subset_file,
     usgs_files,
-    max_fill_1min = 14
+    max_fill_1min = 14,
+    t0 = None,
 ):
     """
     routelink_subset_file - provides the gage-->segment crosswalk
     usgs_files - list of "time-slice" files containing observed values
     max_fill_1min - sets the maximum interpolation length
+    t0 - optional date parameter to trim the front of the files -- if not provided,
+          the interpolated values are truncated so that the first value returned
+          corresponds to the first center date of the first provided file.
     """
     with read_netcdfs(usgs_files, "time", preprocess_time_station_index,) as ds2:
 
@@ -770,6 +774,8 @@ def get_usgs_from_time_slices_folder(
     square-wave signals at gages reporting hourly...
     therefore, we use a 59 minute gap filling tolerance.
     """
+    if t0:
+        date_time_center_start = t0
     # TODO: Add reporting interval information to the gage preprocessing (timeslice generation)
     usgs_df_T = (usgs_df_T.resample('min').
                  interpolate(limit = max_fill_1min, limit_direction = 'both').

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -438,10 +438,10 @@ def get_attribute(nc_file, attribute):
         return xd.attrs[attribute]
 
 
-def build_last_obs_df(
+def build_lastobs_df(
         lastobsfile,
         routelink,
-        wrf_last_obs_flag,
+        wrf_lastobs_flag,
         time_shift = 0,
         gage_id = "gages",
         link_id = "link",
@@ -459,14 +459,14 @@ def build_last_obs_df(
     ):
 
     standard_columns = {
-        "last_obs_discharge": obs_discharge_id,
+        "lastobs_discharge": obs_discharge_id,
         "time_since_lastobs": time_id,
         "gages": gage_id,
         "last_model_discharge": model_discharge_id
     }
 
     """
-    Open last_obs file, import the segment keys from the routelink_file
+    Open lastobs file, import the segment keys from the routelink_file
     and extract discharges.
     """
     # TODO: We should already know the link/gage relationship by this point and can require that as an input
@@ -533,16 +533,18 @@ def build_last_obs_df(
         model_discharge_last_ts[obs_discharge_id] = model_discharge_last_ts[
             obs_discharge_id
         ].to_frame()
-        # If predict from last_obs file use last obs file results
-        # if last_obs_file == "error-based":
-        # elif last_obs_file == "obs-based":  # the wrf-hydro default
+
+        # TODO: Remove any of the following comments that are no longer needed
+        # If predict from lastobs file use last obs file results
+        # if lastobs_file == "error-based":
+        # elif lastobs_file == "obs-based":  # the wrf-hydro default
         # NOTE:  The following would compare potentially mis-matched
         # obs/model pairs, so it is commented until we can figure out
         # a more robust bias-type persistence.
         # For now, we use only obs-type persistence.
         # It would be possible to preserve a 'last_valid_bias' which would
         # presumably correspond to the last_valid_time.
-        # # if wrf_last_obs_flag:
+        # # if wrf_lastobs_flag:
         # #     model_discharge_last_ts[last_nudge_id] = (
         # #         model_discharge_last_ts[obs_discharge_id]
         # #         - model_discharge_last_ts[model_discharge_id]
@@ -734,14 +736,18 @@ def get_usgs_from_time_slices_folder(
     modeled_high = [ 12, 13, 16, 20, 32, 34, 28, 22, 16, 14, 13, 12, 12, 12, 12]
     modeled_shift_late = [ 10, 10, 10, 11, 14, 18, 30, 32, 26, 20, 14, 12, 11, 10, 10]
     modeled_shift_late = [ 11, 14, 18, 30, 32, 26, 20, 14, 12, 11, 10, 10, 10, 10, 10]
-    last_obs = {"obs":9.5, "time":0}  # Most recent observation at simulation start
-    last_obs_old = {"obs":9.5, "time":-3600}  # Most recent observation 1 hour ago
-    last_obs_NaN = {"obs":NaN, "time":NaT}  # No valid recent observation
+    lastobs = {"obs":9.5, "time":0}  # Most recent observation at simulation start
+    lastobs_old = {"obs":9.5, "time":-3600}  # Most recent observation 1 hour ago
+    lastobs_NaN = {"obs":NaN, "time":NaT}  # No valid recent observation
     ```
     """
 
+    #TODO: separate the interpolation into a function; eventually, the data source
+    # could be something other than the time-slice files, but the interpolation
+    # might be the same and the function would facilitate taking advantage of that.
+
     # ---- Laugh testing ------
-    # scren-out erroneous qc flags
+    # screen-out erroneous qc flags
     usgs_qual_df = usgs_qual_df.mask(usgs_qual_df < 0, np.nan)
     usgs_qual_df = usgs_qual_df.mask(usgs_qual_df > 1, np.nan)
 

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -595,6 +595,7 @@ def build_lastobs_df(
         return final_df
 
 
+# TODO: Update get_usgs_from_time_slices_csv with new interpolation method
 def get_usgs_from_time_slices_csv(routelink_subset_file, usgs_csv):
 
     df2 = pd.read_csv(usgs_csv, index_col=0)

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -678,7 +678,7 @@ def build_data_assimilation_lastobs(data_assimilation_parameters):
     )
 
     if lastobs_file:
-        lastobs_df = nhd_io.build_last_obs_df(
+        lastobs_df = nhd_io.build_lastobs_df(
             lastobs_file,
             lastobs_crosswalk_file,
             lastobs_type,  # TODO: Confirm that we are using this; delete it if not.

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -632,7 +632,11 @@ def build_data_assimilation(data_assimilation_parameters):
     return usgs_df, lastobs_df, da_parameter_dict
 
 
-def build_data_assimilation_usgs_df(data_assimilation_parameters, lastobs_index=None):
+def build_data_assimilation_usgs_df(
+    data_assimilation_parameters,
+    lastobs_index=None,
+    t0=None,
+):
     data_assimilation_csv = data_assimilation_parameters.get(
         "data_assimilation_csv", None
     )
@@ -647,7 +651,7 @@ def build_data_assimilation_usgs_df(data_assimilation_parameters, lastobs_index=
     if data_assimilation_csv:
         usgs_df = build_data_assimilation_csv(data_assimilation_parameters)
     elif data_assimilation_folder:
-        usgs_df = build_data_assimilation_folder(data_assimilation_parameters)
+        usgs_df = build_data_assimilation_folder(data_assimilation_parameters, t0)
 
     if not lastobs_index.empty:
         if not usgs_df.empty and not usgs_df.index.equals(lastobs_index):
@@ -702,7 +706,7 @@ def build_data_assimilation_csv(data_assimilation_parameters):
     return usgs_df
 
 
-def build_data_assimilation_folder(data_assimilation_parameters):
+def build_data_assimilation_folder(data_assimilation_parameters, t0=None):
 
     usgs_timeslices_folder = pathlib.Path(
         data_assimilation_parameters["data_assimilation_timeslices_folder"],
@@ -720,7 +724,8 @@ def build_data_assimilation_folder(data_assimilation_parameters):
     usgs_df = nhd_io.get_usgs_from_time_slices_folder(
         data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
         usgs_files,
-        data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59)
+        data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59),
+        t0,
     )
 
     return usgs_df

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -626,16 +626,16 @@ def build_qlateral_array(
     return qlat_df
 
 
-def build_data_assimilation(data_assimilation_parameters):
+def build_data_assimilation(data_assimilation_parameters, run_parameters):
     lastobs_df, da_parameter_dict = build_data_assimilation_lastobs(data_assimilation_parameters)
-    usgs_df = build_data_assimilation_usgs_df(data_assimilation_parameters, lastobs_df.index)
+    usgs_df = build_data_assimilation_usgs_df(data_assimilation_parameters, run_parameters, lastobs_df.index)
     return usgs_df, lastobs_df, da_parameter_dict
 
 
 def build_data_assimilation_usgs_df(
     data_assimilation_parameters,
+    run_parameters,
     lastobs_index=None,
-    t0=None,
 ):
     data_assimilation_csv = data_assimilation_parameters.get(
         "data_assimilation_csv", None
@@ -651,7 +651,7 @@ def build_data_assimilation_usgs_df(
     if data_assimilation_csv:
         usgs_df = build_data_assimilation_csv(data_assimilation_parameters)
     elif data_assimilation_folder:
-        usgs_df = build_data_assimilation_folder(data_assimilation_parameters, t0)
+        usgs_df = build_data_assimilation_folder(data_assimilation_parameters, run_parameters)
 
     if not lastobs_index.empty:
         if not usgs_df.empty and not usgs_df.index.equals(lastobs_index):
@@ -706,8 +706,10 @@ def build_data_assimilation_csv(data_assimilation_parameters):
     return usgs_df
 
 
-def build_data_assimilation_folder(data_assimilation_parameters, t0=None):
+def build_data_assimilation_folder(data_assimilation_parameters, run_parameters=None):
 
+    if not run_parameters:
+        run_parameters = {}
     usgs_timeslices_folder = pathlib.Path(
         data_assimilation_parameters["data_assimilation_timeslices_folder"],
     ).resolve()
@@ -725,7 +727,9 @@ def build_data_assimilation_folder(data_assimilation_parameters, t0=None):
         data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
         usgs_files,
         data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59),
-        t0,
+        run.get("dt", 300),
+        run.get("t0", None)
+        data_assimilation_parameters.get("qc_threshold", 1.0),
     )
 
     return usgs_df

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -438,7 +438,7 @@ def build_connections(supernetwork_parameters):
     param_df = param_df.sort_index()
 
     # TODO: Do we need this second, identical call to the one above?
-    param_df = param_df.rename(columns=nhd_network.reverse_dict(cols)) 
+    param_df = param_df.rename(columns=nhd_network.reverse_dict(cols))
 
     wbodies = {}
     if "waterbody" in cols:

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -285,15 +285,15 @@ def parity_check(
 
         # compare dataframes
         compare = pd.concat([wrf, trt], axis=1, sort=False, join="inner")
-        compare["diff"] = compare["flow, wrf (cms)"] - compare["flow, t-route (cms)"]
+        compare["diff"] = compare["flow, t-route (cms)"] - compare["flow, wrf (cms)"]
         compare["rel_diff"] = (
-            compare["flow, wrf (cms)"] - compare["flow, t-route (cms)"]
+            compare["flow, t-route (cms)"] - compare["flow, wrf (cms)"]
         ) / compare["flow, wrf (cms)"]
         compare["absdiff"] = np.abs(
-            compare["flow, wrf (cms)"] - compare["flow, t-route (cms)"]
+            compare["flow, t-route (cms)"] - compare["flow, wrf (cms)"]
         )
         compare["rel_absdiff"] = np.abs(
-            (compare["flow, wrf (cms)"] - compare["flow, t-route (cms)"])
+            (compare["flow, t-route (cms)"] - compare["flow, wrf (cms)"])
             / compare["flow, wrf (cms)"]
         )
 

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -250,6 +250,7 @@ def parity_check(
     time_wrf = validation_data.columns.values
 
     if compare_node in validation_data.index:
+        print(f"Comparing flows at {compare_node}")
 
         # construct comparable dataframes
         if not parity_check_water_elevation:

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -379,7 +379,7 @@ def compute_nhd_routing_v02(
                             np.array(da_positions_list_byreach, dtype="int32"),
                             np.array(da_positions_list_bygage, dtype="int32"),
                             lastobs_df_sub.get(
-                                "last_obs_discharge",
+                                "lastobs_discharge",
                                 pd.Series(index=lastobs_df_sub.index, name="Null"),
                             ).values.astype("float32"),
                             lastobs_df_sub.get(
@@ -590,7 +590,7 @@ def compute_nhd_routing_v02(
                             np.array(da_positions_list_byreach, dtype="int32"),
                             np.array(da_positions_list_bygage, dtype="int32"),
                             lastobs_df_sub.get(
-                                "last_obs_discharge",
+                                "lastobs_discharge",
                                 pd.Series(index=lastobs_df_sub.index, name="Null"),
                             ).values.astype("float32"),
                             lastobs_df_sub.get(
@@ -786,7 +786,7 @@ def compute_nhd_routing_v02(
                             np.array(da_positions_list_byseg, dtype="int32"),
                             np.array(da_positions_list_byreach, dtype="int32"),
                             np.array(da_positions_list_bygage, dtype="int32"),
-                            lastobs_df_sub.get("last_obs_discharge", pd.Series(index=lastobs_df_sub.index, name="Null")).values.astype("float32"),
+                            lastobs_df_sub.get("lastobs_discharge", pd.Series(index=lastobs_df_sub.index, name="Null")).values.astype("float32"),
                             lastobs_df_sub.get("time_since_lastobs", pd.Series(index=lastobs_df_sub.index, name="Null")).values.astype("float32"),
                             da_decay_coefficient,
                             # flowveldepth_interorder,  # obtain keys and values from this dataset
@@ -934,7 +934,7 @@ def compute_nhd_routing_v02(
                         np.array(da_positions_list_byseg, dtype="int32"),
                         np.array(da_positions_list_byreach, dtype="int32"),
                         np.array(da_positions_list_bygage, dtype="int32"),
-                        lastobs_df_sub.get("last_obs_discharge", pd.Series(index=lastobs_df_sub.index, name="Null")).values.astype("float32"),
+                        lastobs_df_sub.get("lastobs_discharge", pd.Series(index=lastobs_df_sub.index, name="Null")).values.astype("float32"),
                         lastobs_df_sub.get("time_since_lastobs", pd.Series(index=lastobs_df_sub.index, name="Null")).values.astype("float32"),
                         da_decay_coefficient,
                         {},
@@ -1052,7 +1052,7 @@ def compute_nhd_routing_v02(
                     np.array(da_positions_list_byseg, dtype="int32"),
                     np.array(da_positions_list_byreach, dtype="int32"),
                     np.array(da_positions_list_bygage, dtype="int32"),
-                    lastobs_df_sub.get("last_obs_discharge", pd.Series(index=lastobs_df_sub.index, name="Null")).values.astype("float32"),
+                    lastobs_df_sub.get("lastobs_discharge", pd.Series(index=lastobs_df_sub.index, name="Null")).values.astype("float32"),
                     lastobs_df_sub.get("time_since_lastobs", pd.Series(index=lastobs_df_sub.index, name="Null")).values.astype("float32"),
                     da_decay_coefficient,
                     {},

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -1229,9 +1229,9 @@ cpdef object compute_network_structured(
     cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), np.iinfo(np.int32).min, dtype="int32")
     cdef float[:,:] nudge = np.zeros((gages_size, nsteps + 1), dtype="float32")
 
+    lastobs_times = np.full(gages_size, NAN, dtype="float32")
+    lastobs_values = np.full(gages_size, NAN, dtype="float32")
     if gages_size:
-        lastobs_times = np.zeros(gages_size, dtype="float32")
-        lastobs_values = np.zeros(gages_size, dtype="float32")
         # if da_check_gage > 0:
         #     print(f"gage_i     usgs_positions[gage_i]  usgs_positions_reach[gage_i]  usgs_positions_gage[gage_i]   list(usgs_positions)")
         for gage_i in range(gages_size):
@@ -1412,4 +1412,4 @@ cpdef object compute_network_structured(
     #slice off the initial condition timestep and return
     output = np.asarray(flowveldepth[:,1:,:], dtype='float32')
     #return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth.base.reshape(flowveldepth.shape[0], -1), dtype='float32')
-    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], output.reshape(output.shape[0], -1)[fill_index_mask]
+    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], output.reshape(output.shape[0], -1)[fill_index_mask], 0, (np.asarray([data_idx[usgs_position_i] for usgs_position_i in usgs_positions]), np.asarray(lastobs_times), np.asarray(lastobs_values))

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -1351,7 +1351,7 @@ cpdef object compute_network_structured(
                         segment = get_mc_segment(r, _i)
                         flowveldepth[segment.id, timestep, 0] = out_buf[_i, 0]
                         if reach_has_gage[i] == da_check_gage:
-                            printf("segment.id: %d\t", segment.id)
+                            printf("segment.id: %ld\t", segment.id)
                             printf("segment.id: %d\t", usgs_positions[reach_has_gage[i]])
                         flowveldepth[segment.id, timestep, 1] = out_buf[_i, 1]
                         flowveldepth[segment.id, timestep, 2] = out_buf[_i, 2]
@@ -1388,7 +1388,8 @@ cpdef object compute_network_structured(
                         printf("gmxt: %d\t", gage_maxtimestep)
                         printf("gage: %d\t", gage_i)
                         printf("old: %g\t", flowveldepth[usgs_position_i, timestep, 0])
-                        printf("exp_gage_val: %g\t", usgs_values[gage_i,timestep])
+                        printf("exp_gage_val: %g\t", 
+                        NAN if timestep >= gage_maxtimestep else usgs_values[gage_i,timestep],)
 
                     flowveldepth[usgs_position_i, timestep, 0] = da_buf[0]
 

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
@@ -49,14 +49,14 @@ cdef (float, float, float, float) simple_da(
         replacement_val = target_val
         nudge_val = target_val - model_val
         # add/update lastobs_timestep
-        lastobs_time = (timestep - 1) * routing_period
+        lastobs_time = (timestep) * routing_period
         lastobs_val = target_val
     else:
         if da_check_gage:
             printf("So we are fixing that...\t")
         if da_check_gage:
             printf("decay; target: %g\t", target_val)
-        da_decay_minutes = ((timestep - 1) * routing_period - lastobs_time) / 60 # seconds to minutes
+        da_decay_minutes = ((timestep) * routing_period - lastobs_time) / 60 # seconds to minutes
         da_weighted_shift = obs_persist_shift(lastobs_val, model_val, da_decay_minutes, decay_coeff)
         nudge_val = da_weighted_shift
         # TODO: we need to export these values

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
@@ -68,7 +68,7 @@ cdef (float, float, float, float) simple_da(
             printf("ts: %g\t", timestep)
             printf("dt: %g\t", routing_period)
             printf("min: %g\t", da_decay_minutes)
-            printf("lo_t: %d\t", lastobs_time)
+            printf("lo_t: %f\t", lastobs_time)
             printf("lov: %g\t", lastobs_val)
             printf("ndg: %g\t", da_weighted_shift)
             printf("orig: %g\t", model_val)

--- a/test/input/yaml/Florence_Benchmark_da.yaml
+++ b/test/input/yaml/Florence_Benchmark_da.yaml
@@ -95,9 +95,9 @@ data_assimilation_parameters:
     data_assimilation_timeslices_folder: "../../test/input/florence_fullres/florenceNudgingChannelOnly/nudgingTimeSliceObs_calibration"
     data_assimilation_filter: "2018-09-18_0[0-9]*.usgsTimeSlice.ncdf"
     wrf_hydro_da_channel_ID_crosswalk_file: "../../test/input/florence_933020089/DOMAIN/Route_Link.nc"
-    wrf_hydro_last_obs_file: "../../test/input/florence_fullres/florenceNudgingChannelOnly/nudgingLastObs/nudgingLastObs.2018-09-18_00:00:00.nc"
-    wrf_hydro_last_obs_lead_time_relative_to_simulation_start_time: 0
-    wrf_last_obs_type: "obs-based"
+    wrf_hydro_lastobs_file: "../../test/input/florence_fullres/florenceNudgingChannelOnly/nudgingLastObs/nudgingLastObs.2018-09-18_00:00:00.nc"
+    wrf_hydro_lastobs_lead_time_relative_to_simulation_start_time: 0
+    wrf_lastobs_type: "obs-based"
     da_decay_coefficient: 120  # `a` parameter in WRF-Hydro
     # 2018-12-31_23:45:00.15min.usgsTimeSlice.ncdf
     # data_assimilation_csv: "../../test/input/geo/usgs_files/usgs_files.csv"


### PR DESCRIPTION
This PR is built off of the fixes found in jameshalgren/long-term-looping-all.

This should solve the issues found in:
**https://github.com/NOAA-OWP/t-route/issues/433**

marked at:

- https://github.com/NOAA-OWP/t-route/blob/4ec74cc70d4f1ca407d20a6764b3f89facb43a96/src/python_framework_v02/troute/nhd_io.py#L757

- https://github.com/NOAA-OWP/t-route/blob/4ec74cc70d4f1ca407d20a6764b3f89facb43a96/src/python_framework_v02/troute/nhd_io.py#L652

- https://github.com/NOAA-OWP/t-route/blob/4ec74cc70d4f1ca407d20a6764b3f89facb43a96/src/python_framework_v02/troute/nhd_io.py#L776

The frequency needed to be calculated using the run_parameters['dt']. I made a few changes to pass run_parameters through the necessary functions to get it there. Additionally, a slight modification to data_assimilation_parameters to add both data_assimilation_interpolation_limit: 14 and QC_threshold: 1. These can now be specified and passed from the YAML to the functions found in .io.

The files I made changes to are the Florence_fcast_da_5min, main, nhd_io, and nhd_network_utilities.